### PR TITLE
0.0.13 Fixed Dependencies

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,10 +1,14 @@
 # Changelog
 
-## 0.0.12 Fixed Dependencies
+## 0.0.13 Fixed Dependencies
 
-- Fixes `gaclen_shader` in external projects.
+- Fixes `gaclen_shader` in external projects
+- Updates `gaclen_shader` crate-level documentation
 - Updates `vulkano` dependency `0.17.0 -> 0.18.0`
 - Updates `winit` dependency `0.21.0` -> `0.22.1`
+- Make examples more copy-pasteable
+
+## 0.0.12 -YANKED-
 
 ## 0.0.11 Attached Viewports
 

--- a/gaclen/Cargo.toml
+++ b/gaclen/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gaclen"
-version = "0.0.12"
+version = "0.0.13"
 authors = ["Grigory 'Griffone' Glukhov <thegriffones@gmail.com>"]
 edition = "2018"
 
@@ -26,4 +26,4 @@ vulkano-win = "0.18.0" # vulkan-winit linkage
 [dev-dependencies]
 cgmath = "0.17.0" # linear algebra library
 image = "0.22.3"
-gaclen_shader = { path = "../gaclen_shader", version = "0.0.12" }
+gaclen_shader = { path = "../gaclen_shader", version = "0.0.13" }

--- a/gaclen/examples/phong_cube/main.rs
+++ b/gaclen/examples/phong_cube/main.rs
@@ -5,12 +5,14 @@
 //! 
 //! Please note, that because of screen-space coordinate mismatch between OpenGL and Vulkan the `up` coordinate and triangle-faces are reversed.
 
+// Allow `shader!` macro to use this project's gaclen dependency.
 extern crate gaclen;
 
 mod shaders;
 mod geometry;
 
 use gaclen::graphics;
+use gaclen::winit;
 
 use cgmath::One;
 

--- a/gaclen/examples/quad/main.rs
+++ b/gaclen/examples/quad/main.rs
@@ -4,11 +4,13 @@
 //! 
 //! Please note, that because of screen-space coordinate mismatch between OpenGL and Vulkan the `up` coordinate is reversed.
 
+// Allow `shader!` macro to use this project's gaclen dependency.
 extern crate gaclen;
 
 mod shaders;
 
 use gaclen::graphics;
+use gaclen::winit;
 
 use winit::event_loop::{ControlFlow, EventLoop};
 use winit::event::{Event, WindowEvent};

--- a/gaclen/examples/shadow/main.rs
+++ b/gaclen/examples/shadow/main.rs
@@ -1,9 +1,11 @@
+// Allow `shader!` macro to use this project's gaclen dependency.
 extern crate gaclen;
 
 mod shaders;
 mod geometry;
 
 use gaclen::graphics;
+use gaclen::winit;
 
 use cgmath::{One, Rotation};
 

--- a/gaclen_shader/Cargo.toml
+++ b/gaclen_shader/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gaclen_shader"
-version = "0.0.12"
+version = "0.0.13"
 authors = ["Grigory 'Griffone' Glukhov <thegriffones@gmail.com>"]
 edition = "2018"
 

--- a/gaclen_shader/src/codegen.rs
+++ b/gaclen_shader/src/codegen.rs
@@ -7,7 +7,7 @@
 // notice may not be copied, modified, or distributed except
 // according to those terms.
 
-// The only changes from the crate::gaclen::graphics::vulkano-shaders is using crate::gaclen::graphicscrate::gaclen::graphics::vulkano instead of crate::gaclen::graphics::vulkano in the generated code
+// The only changes from the crate::gaclen::graphics::vulkano-shaders is using crate::gaclen::graphics::vulkano instead of ::vulkano in the generated code
 
 use std::io::Error as IoError;
 use std::path::Path;

--- a/gaclen_shader/src/entry_point.rs
+++ b/gaclen_shader/src/entry_point.rs
@@ -56,7 +56,7 @@ pub fn write_entry_point(doc: &Spirv, instruction: &Instruction) -> (TokenStream
     let (ty, f_call) = {
         if let ExecutionModel::ExecutionModelGLCompute = *execution {
             (
-                quote!{ ::vulkano::pipeline::shader::ComputeEntryPoint<#spec_consts_struct, Layout> },
+                quote!{ crate::gaclen::graphics::vulkano::pipeline::shader::ComputeEntryPoint<#spec_consts_struct, Layout> },
                 quote!{ compute_entry_point(
                     ::std::ffi::CStr::from_ptr(NAME.as_ptr() as *const _),
                     Layout(ShaderStages { compute: true, .. ShaderStages::none() })
@@ -65,13 +65,13 @@ pub fn write_entry_point(doc: &Spirv, instruction: &Instruction) -> (TokenStream
         } else {
             let entry_ty = match *execution {
                 ExecutionModel::ExecutionModelVertex =>
-                    quote!{ ::vulkano::pipeline::shader::GraphicsShaderType::Vertex },
+                    quote!{ crate::gaclen::graphics::vulkano::pipeline::shader::GraphicsShaderType::Vertex },
 
                 ExecutionModel::ExecutionModelTessellationControl =>
-                    quote!{ ::vulkano::pipeline::shader::GraphicsShaderType::TessellationControl },
+                    quote!{ crate::gaclen::graphics::vulkano::pipeline::shader::GraphicsShaderType::TessellationControl },
 
                 ExecutionModel::ExecutionModelTessellationEvaluation =>
-                    quote!{ ::vulkano::pipeline::shader::GraphicsShaderType::TessellationEvaluation },
+                    quote!{ crate::gaclen::graphics::vulkano::pipeline::shader::GraphicsShaderType::TessellationEvaluation },
 
                 ExecutionModel::ExecutionModelGeometry => {
                     let mut execution_mode = None;
@@ -95,14 +95,14 @@ pub fn write_entry_point(doc: &Spirv, instruction: &Instruction) -> (TokenStream
                     }
 
                     quote!{
-                        ::vulkano::pipeline::shader::GraphicsShaderType::Geometry(
-                            ::vulkano::pipeline::shader::GeometryShaderExecutionMode::#execution_mode
+                        crate::gaclen::graphics::vulkano::pipeline::shader::GraphicsShaderType::Geometry(
+                            crate::gaclen::graphics::vulkano::pipeline::shader::GeometryShaderExecutionMode::#execution_mode
                         )
                     }
                 }
 
                 ExecutionModel::ExecutionModelFragment =>
-                    quote!{ ::vulkano::pipeline::shader::GraphicsShaderType::Fragment },
+                    quote!{ crate::gaclen::graphics::vulkano::pipeline::shader::GraphicsShaderType::Fragment },
 
                 ExecutionModel::ExecutionModelGLCompute => unreachable!(),
 
@@ -138,7 +138,7 @@ pub fn write_entry_point(doc: &Spirv, instruction: &Instruction) -> (TokenStream
             let capitalized_ep_name_output = Ident::new(&capitalized_ep_name_output, Span::call_site());
 
             let ty = quote!{
-                ::vulkano::pipeline::shader::GraphicsEntryPoint<
+                crate::gaclen::graphics::vulkano::pipeline::shader::GraphicsEntryPoint<
                     #spec_consts_struct,
                     #capitalized_ep_name_input,
                     #capitalized_ep_name_output,
@@ -274,9 +274,9 @@ fn write_interface_struct(struct_name_str: &str, attributes: &[Element]) -> Toke
                 if self.num == #num {
                     self.num += 1;
 
-                    return Some(::vulkano::pipeline::shader::ShaderInterfaceDefEntry {
+                    return Some(crate::gaclen::graphics::vulkano::pipeline::shader::ShaderInterfaceDefEntry {
                         location: #loc .. #loc_end,
-                        format: ::vulkano::format::Format::#format,
+                        format: crate::gaclen::graphics::vulkano::format::Format::#format,
                         name: Some(::std::borrow::Cow::Borrowed(#name))
                     });
                 }
@@ -297,7 +297,7 @@ fn write_interface_struct(struct_name_str: &str, attributes: &[Element]) -> Toke
         pub struct #struct_name;
 
         #[allow(unsafe_code)]
-        unsafe impl ::vulkano::pipeline::shader::ShaderInterfaceDef for #struct_name {
+        unsafe impl crate::gaclen::graphics::vulkano::pipeline::shader::ShaderInterfaceDef for #struct_name {
             type Iter = #iter_name;
             fn elements(&self) -> #iter_name {
                  #iter_name { num: 0 }
@@ -308,7 +308,7 @@ fn write_interface_struct(struct_name_str: &str, attributes: &[Element]) -> Toke
         pub struct #iter_name { num: u16 }
 
         impl Iterator for #iter_name {
-            type Item = ::vulkano::pipeline::shader::ShaderInterfaceDefEntry;
+            type Item = crate::gaclen::graphics::vulkano::pipeline::shader::ShaderInterfaceDefEntry;
 
             #[inline]
             fn next(&mut self) -> Option<Self::Item> {

--- a/gaclen_shader/src/lib.rs
+++ b/gaclen_shader/src/lib.rs
@@ -1,5 +1,11 @@
 //! Tweaked version of [vulkano_shader!](https://docs.rs/crate/vulkano-shaders) macro.
 //! 
+//! In order to function the macro requires access to gaclen crate:
+//! ```
+//! // Allow `shader!` macro to use this project's gaclen dependency.
+//! extern crate gaclen;
+//! ```
+//! 
 //! The changes include tweaks to the generated code to use gaclen::vulkano to avoid the necessity of including vulkano in gaclen-dependent projects.
 
 #![recursion_limit = "1024"]


### PR DESCRIPTION
- Fixes `gaclen_shader` in external projects
- Updates `gaclen_shader` crate-level documentation
- Updates `vulkano` dependency `0.17.0 -> 0.18.0`
- Updates `winit` dependency `0.21.0` -> `0.22.1`
- Make examples more copy-pasteable
