### PR TITLE
0.0.14 Copy Buffers

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,8 +2,11 @@
 
 ## 0.0.14 Copy Buffers
 
-- Adds device-local buffer creation methods
-- Adds buffer update and copy methods
+- Adds methods for creating `DeviceLocalBuffer`s:
+  - `buffer::create_device_local_buffer()`
+  - `buffer::create_device_local_array_buffer()`
+- Adds `buffer::update()` for updating buffer data
+- Adds `buffer::copy()` for copying data from one buffer to another
 - Adds an optional `serde` dependency that should enable winit `serde` features
 
 ## 0.0.13 Fixed Dependencies

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.0.14 Copy Buffers
+
+- Adds device-local buffer creation methods
+- Adds buffer update and copy methods
+- Adds an optional `serde` dependency that should enable winit `serde` features
+
 ## 0.0.13 Fixed Dependencies
 
 - Fixes `gaclen_shader` in external projects

--- a/gaclen/Cargo.toml
+++ b/gaclen/Cargo.toml
@@ -19,7 +19,8 @@ default = []
 expose-underlying-vulkano = []
 
 [dependencies]
-winit = "0.22.1" # window handling
+winit = "0.22" # window handling
+serde = { version = "1", optional = true, features = ["serde_derive"] }
 vulkano = "0.18.0" # vulkan library in Rust
 vulkano-win = "0.18.0" # vulkan-winit linkage
 

--- a/gaclen/src/graphics/device.rs
+++ b/gaclen/src/graphics/device.rs
@@ -68,7 +68,6 @@ impl Device {
 	pub fn logical_device(&self) -> Arc<LogicalDevice> { self.device.clone() }
 }
 
-// Member exposure
 #[cfg(feature = "expose-underlying-vulkano")]
 impl Device {
 	/// Get the [vulkano device queue](struct.DeviceQueue.html) used for graphical operations.
@@ -206,6 +205,7 @@ fn choose_better_graphics_family<'a>(first: vulkano::instance::QueueFamily<'a>, 
 fn choose_better_transfer_family<'a>(first: vulkano::instance::QueueFamily<'a>, second: vulkano::instance::QueueFamily<'a>) -> vulkano::instance::QueueFamily<'a> {
 	if !second.explicitly_supports_transfers() { return first; };
 
+	// prefer exclusively transfer operations
 	match second.supports_graphics() {
 		true => first,
 		false => match first.supports_graphics() {

--- a/gaclen/src/graphics/pass/graphical_pass.rs
+++ b/gaclen/src/graphics/pass/graphical_pass.rs
@@ -19,6 +19,12 @@ impl GraphicalPass<()> {
 	pub fn start() -> GraphicalPassBuilder<(), (), (), (), ()> { GraphicalPassBuilder::new() }
 }
 
+#[cfg(feature="expose-underlying-vulkano")]
+impl<P: ?Sized> GraphicalPass<P> {
+	#[inline]
+	pub fn pipeline(&self) -> Arc<P> { self.pipeline }
+}
+
 impl<P : ?Sized> GraphicalPass<P>
 {
 	/// Start building a new persistent descriptor set.


### PR DESCRIPTION
- Adds methods for creating `DeviceLocalBuffer`s:
  - `buffer::create_device_local_buffer()`
  - `buffer::create_device_local_array_buffer()`
- Adds `buffer::update()` for updating buffer data
- Adds `buffer::copy()` for copying data from one buffer to another
- Adds an optional `serde` dependency that should enable winit `serde` features
